### PR TITLE
Make io_service visible

### DIFF
--- a/include/base.hpp
+++ b/include/base.hpp
@@ -415,6 +415,11 @@ public:
         return 0;
     }
 
+    ios_ptr io_service()
+    {
+      return ios_;
+    }
+
 private:
 
     ios_ptr ios_;

--- a/include/router.hpp
+++ b/include/router.hpp
@@ -12,7 +12,7 @@ template<class ReqBody>
 class router{
 
     using self = router<ReqBody>;
-    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>>;
+    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>, std::vector<std::string>>;
     using resource_map_t = boost::unordered_map<resource_regex_t,typename list_cb_t::ptr>;
     using method_map_t = std::map<method_t, resource_map_t>;
 
@@ -81,8 +81,9 @@ protected:
                             boost::bind<void>(
                                 value,
                                 boost::placeholders::_1,
-                                boost::placeholders::_2
-                                )
+                                boost::placeholders::_2,
+                                boost::placeholders::_3
+                              )
                             )
                         );
         };
@@ -185,7 +186,7 @@ class basic_router : public router<ReqBody>{
 
     using base_t = router<ReqBody>;
     using self = basic_router<ReqBody>;
-    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>>;
+    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>, std::vector<std::string>>;
     using resource_map_t = boost::unordered_map<resource_regex_t,typename list_cb_t::ptr>;
     using method_map_t = std::map<method_t, resource_map_t>;
 
@@ -404,7 +405,7 @@ class chain_router : public router<ReqBody>{
 
     using base_t = router<ReqBody>;
     using self = chain_router<ReqBody>;
-    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>>;
+    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>, std::vector<std::string>>;
     using resource_map_t = boost::unordered_map<resource_regex_t,typename list_cb_t::ptr>;
     using method_map_t = std::map<method_t, resource_map_t>;
 

--- a/include/server.hpp
+++ b/include/server.hpp
@@ -16,7 +16,7 @@ class server_impl{
 
     using basic_r = basic_router<ReqBody>;
     using chain_r = chain_router<ReqBody>;
-    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>>;
+    using list_cb_t = list_cb<boost::beast::http::request<ReqBody>, session<true, ReqBody>, std::vector<std::string>>;
     using resource_map_t = boost::unordered_map<resource_regex_t,typename list_cb_t::ptr>;
     using method_map_t = std::map<method_t, resource_map_t>;
 


### PR DESCRIPTION
I need to use io_service outside the http_server, because need to access serial ports
boost::asio::serial_port

Maybe there is a better way to make it visible.