### PR TITLE
Bugfixing on connection problems

### DIFF
--- a/include/base.hpp
+++ b/include/base.hpp
@@ -350,13 +350,14 @@ public:
         boost::asio::ip::tcp::resolver::query query(address, boost::lexical_cast<std::string>(port));
 
         boost::system::error_code ec;
-        boost::asio::ip::tcp::endpoint endpoint = *resolver.resolve(query, ec);
 
+        auto resolved = resolver.resolve(query, ec);
         if(ec){
             fail(ec, "resolve");
             return {};
         }
 
+        boost::asio::ip::tcp::endpoint endpoint = *resolved;
         return std::make_shared<tcp_connection>(*ios_, endpoint, std::forward<F>(f));
     }
 

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -40,6 +40,13 @@ public:
             session<false, ResBody>::on_connect(connection_p_, response_cb_p_, handler_);
         });
 
+        if(!connection_p_){
+            response_cb_p_ = {};
+            base::processor::get().stop();
+
+            return;
+        }
+
         typename list_cb_t::L cb{
             boost::bind<void>(
                         std::forward<Callback2>(on_receive_handler),
@@ -48,10 +55,7 @@ public:
                         )
         };
 
-        if(connection_p_)
-            response_cb_p_ = std::make_shared<list_cb_t>(cb);
-        else
-            response_cb_p_ = {};
+        response_cb_p_ = std::make_shared<list_cb_t>(cb);
     }
 
 private:

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -34,8 +34,10 @@ public:
         connection_p_ = base::processor::get().create_connection(host,
                                                                  port,
                                                                  [this, handler_ = std::forward<Callback1>(on_connect_handler)](const boost::system::error_code & ec){
-            if(ec)
+            if(ec){
+                connection_p_->socket().get_executor().context().stop();
                 return base::fail(ec, "connect");
+            }
 
             session<false, ResBody>::on_connect(connection_p_, response_cb_p_, handler_);
         });


### PR DESCRIPTION
Thanks for the nice lib! However, these are the errors I encountered:

- When host cannot be resolved, the object returned from resolver is not dereferencable, resulting in a crash. Need to separate resolving and dereferencing.
- When crash on unsuccessful resolve is fixed, `http::base::processor::get().wait();` hangs (see client example), because there is no response coming, but asio waits for one. Need to stop `base::processor` to unblock `io_service::run()`.
- Same for connection refused, e.g. closed port on host. Need to stop execution context of connection to unblock `io_service::run()`.

Please find in this merge request fixes for all the above. Note that I only tested in as a HTTP client. I assume that the changes do not afflict server use case, but I am not sure.