### PR TITLE
need access to underlying session for long running data transfer

### DIFF
--- a/include/session.hpp
+++ b/include/session.hpp
@@ -83,6 +83,11 @@ public:
         connection_p_->shutdown();
     }
 
+    base::tcp_connection::ptr getConnection()
+    {
+      return connection_p_;
+    }
+
 private:
 
     explicit session(){}


### PR DESCRIPTION
Hi, me again :)

I'm starting an external process (avrdude programming an arduino), and I stream the output of the process to the browser.
see example: https://github.com/saarbastler/IotHttpServer/blob/master/SerialHost/Process.h

The normal return from a handler will immediately close the tcp_connection, but the process takes some time. Now this tcp_connectionwill be closed after the process terminates.

I jus need a public getter to the underlying tcp_connection.
