### PR TITLE
Compile waring on VS2017: C4267 var' : conversion from 'size_t' to 't…

### DIFF
--- a/include/param.hpp
+++ b/include/param.hpp
@@ -591,7 +591,7 @@ protected:
                 auto target = req.target().to_string();
                 if (boost::regex_match(target, what, expr))
                     for(size_t i = 1; i < what.size(); i++)
-                        shared_block_p_->str_args.push_back(what[i]);
+                        shared_block_p_->str_args.push_back(what[int(i)]);
             }
 
             if(shared_block_p_->str_args.size() >= 1){

--- a/include/param.hpp
+++ b/include/param.hpp
@@ -509,7 +509,7 @@ protected:
     using router_ref = std::add_lvalue_reference_t<Router>;
     using regex_pack_t = std::list<resource_regex_t>;
 
-    struct shared_block : private std::enable_shared_from_this<shared_block>{
+    struct shared_block : public std::enable_shared_from_this<shared_block>{
         router_ref router_;
         size_t cur_pos_cb_ = 0;
         regex_pack_t regex_pack;


### PR DESCRIPTION
…ype', possible loss of data

boost::match_result operator [] expects an int