### PR TITLE
More Boost 1.70.0 support needed by recent commit.

### DIFF
--- a/BeastHttp/include/http/common/detect.hxx
+++ b/BeastHttp/include/http/common/detect.hxx
@@ -19,7 +19,7 @@ template</*Message's buffer*/
          class Buffer = boost::beast::flat_buffer,
          /*connection*/
          class Protocol = boost::asio::ip::tcp,
-         template<typename> class Socket = boost::asio::basic_stream_socket,
+         class Socket = boost::asio::basic_stream_socket<Protocol>,
          /*timer*/
          class Clock = boost::asio::chrono::steady_clock,
          template<typename, typename...> class Timer = boost::asio::basic_waitable_timer,
@@ -40,7 +40,7 @@ public:
 
     using protocol_type = Protocol;
 
-    using socket_type = Socket<protocol_type>;
+    using socket_type = Socket;
 
     using buffer_type = Buffer;
 

--- a/BeastHttp/include/http/common/impl/detect.hxx
+++ b/BeastHttp/include/http/common/impl/detect.hxx
@@ -4,7 +4,7 @@
 #define BEASTHTTP_COMMON_DETECT_TMPL_DECLARE \
     template<class Buffer, \
              class Protocol, \
-             template<typename> class Socket, \
+             class Socket, \
              class Clock, \
              template<typename, typename...> class Timer, \
              template<typename> class OnError, \


### PR DESCRIPTION
The recent commit 20a21a0 caused my code to start pulling in detect.hxx (which I'm not certain was the goal, as it didn't seem to be needed by some of those files before?); this exposed another place where Boost 1.70.0 updates were required.