### PR TITLE
Add missing 'inline' qualifiers

### DIFF
--- a/BeastHttp/include/http/base/impl/regex.hxx
+++ b/BeastHttp/include/http/base/impl/regex.hxx
@@ -5,11 +5,13 @@ namespace _0xdead4ead {
 namespace http {
 namespace base {
 
+inline
 regex::regex(flag_type flags)
     : flags_{flags}
 {
 }
 
+inline
 bool
 regex::match(const std::string& regx, const std::string& str)
 {
@@ -17,6 +19,7 @@ regex::match(const std::string& regx, const std::string& str)
     return std::regex_match(str, e);
 }
 
+inline
 bool
 regex::match(const std::string& regx, const std::string& str,
       std::smatch& results)


### PR DESCRIPTION
Non-templated definitions in regex.hxx were triggering link conflicts since they
lacked 'inline' modifiers.